### PR TITLE
Allow Binary Push

### DIFF
--- a/cabby/cli/push.py
+++ b/cabby/cli/push.py
@@ -1,5 +1,6 @@
 
 import logging
+import mimetypes
 
 from cabby.entities import ContentBinding
 from cabby.constants import CB_STIX_XML_111
@@ -38,7 +39,18 @@ def extend_arguments(parser):
 
 def _runner(client, path, args):
 
-    with open(args.content_file, 'r') as f:
+    content_file_path = args.content_file
+    content_file_type = mimetypes.guess_type(content_file_path)
+
+    readability = None
+
+    if content_file_type[0][:4] == "text" or \
+        (content_file_type[0] == None and content_file_type[1] == None):
+        readability = 'r'
+    else:
+        readability = 'rb'
+
+    with open(content_file_path, readability) as f:
         content = f.read()
 
     if args.binding and args.subtypes:


### PR DESCRIPTION
## Summary
This PR is to start the process of allowing binary data to be pushed to a TAXII server which will accept it.

## Purpose 
This PR is meant to fix issue #61 by allowing users to pass in a binary file. This still does not fix the [most recent issue update](https://github.com/eclecticiq/cabby/issues/61#issuecomment-529079379) as of September 7, 2016:

> It's weird because it accepts a binary file in cabby.client11.push, but then when i try to push it to test.taxiistand.com it throws a broken pipe SSL error!

I believe this error exists because `urllib` is not equipped to autoescape unicode strings, as shown in the traceback in the linked issue update.

## Issues yet to be resolved
- [ ] Broken Pipe SSL Error
  - [ ] `client10.py`
  - [ ] `client11.py`