### PR TITLE
Create client from URL

### DIFF
--- a/cabby/__init__.py
+++ b/cabby/__init__.py
@@ -1,6 +1,7 @@
 '''
     Cabby, python library for interacting with TAXII servers.
 '''
+from urllib.parse import urlparse
 
 from ._version import __version__  # noqa: used in setup.py
 
@@ -9,7 +10,7 @@ from .client11 import Client11
 
 
 def create_client(host=None, port=None, discovery_path=None, use_https=False,
-                  version="1.1", headers=None):
+                  url=None, version="1.1", headers=None):
     '''Create a client instance (TAXII version specific).
 
     ``host``, ``port``, ``use_https``, ``discovery_path`` values
@@ -27,6 +28,16 @@ def create_client(host=None, port=None, discovery_path=None, use_https=False,
     :rtype: :py:class:`cabby.client11.Client11` or
             :py:class:`cabby.client10.Client10`
     '''
+    if url:
+        parsed = urlparse(url)
+        if not host and parsed.hostname:
+            host = parsed.hostname
+        if not port and parsed.port:
+            port = parsed.port
+        if not discovery_path and parsed.path:
+            discovery_path = parsed.path
+        if parsed.scheme:
+            use_https = parsed.scheme == 'https'
 
     params = dict(
         host=host,

--- a/cabby/__init__.py
+++ b/cabby/__init__.py
@@ -21,6 +21,7 @@ def create_client(host=None, port=None, discovery_path=None, use_https=False,
     :param int port: TAXII server port
     :param str discovery_path: Discovery Service relative path
     :param bool use_https: if HTTPS should be used
+    :param string url: URL to infer host, port, discovery_path, and use_https
     :param string version: TAXII version (1.1 or 1.0)
     :param dict headers: additional headers to pass with TAXII messages
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,10 @@
+import cabby
+
+
+def test_url_parse():
+    url = 'https://eiq-test.com:1337/path/to/discovery'
+    client = cabby.create_client(url=url)
+    assert client.host == 'eiq-test.com'
+    assert client.port == 1337
+    assert client.use_https is True
+    assert client.discovery_path == '/path/to/discovery'


### PR DESCRIPTION
Allow passing `url` into `create_client` to fill in other params from it. It could be helpful for easier application configuration through env vars, for example. See [dj-database-url](https://github.com/jacobian/dj-database-url) for more info about the motivation.

Close #13 