### PR TITLE
Refresh JWT and retry request once on UNAUTHORIZED status message

### DIFF
--- a/cabby/exceptions.py
+++ b/cabby/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class ClientException(Exception):
     pass
 
@@ -18,7 +16,7 @@ class InvalidResponseError(ClientException):
 class UnsuccessfulStatusError(ClientException):
 
     def __init__(self, taxii_status, *args, **kwargs):
-        msg = "Server Error: {}".format(_status_to_message(self.raw))
+        msg = "Server Error: {}".format(_status_to_message(taxii_status))
         super(UnsuccessfulStatusError, self).__init__(msg, *args, **kwargs)
 
         self.status = taxii_status.status_type

--- a/tests/fixtures10.py
+++ b/tests/fixtures10.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-HOST = 'example.locahost'
+HOST = 'example.localhost'
 
 DISCOVERY_PATH = '/some/discovery/path'
 DISCOVERY_URI_HTTP = "http://%s%s" % (HOST, DISCOVERY_PATH)
@@ -115,3 +115,14 @@ SUBSCRIPTION_RESPONSE = '''
 INBOX_RESPONSE = '''
 <taxii:Status_Message xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1" xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1" xmlns:tdq="http://taxii.mitre.org/query/taxii_default_query-1" message_id="48205" in_response_to="13777" status_type="SUCCESS"/>
 '''
+
+STATUS_MESSAGE_UNAUTHORIZED = """\
+<?xml version="1.0"?>
+<taxii:Status_Message
+    xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1"
+    xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1"
+    xmlns:tdq="http://taxii.mitre.org/query/taxii_default_query-1"
+    message_id="123123"
+    in_response_to="0"
+    status_type="UNAUTHORIZED"/>
+"""

--- a/tests/fixtures11.py
+++ b/tests/fixtures11.py
@@ -139,3 +139,14 @@ SUBSCRIPTION_RESPONSE = '''
 INBOX_RESPONSE = '''
 <taxii_11:Status_Message xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1" xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1" xmlns:tdq="http://taxii.mitre.org/query/taxii_default_query-1" message_id="83710" in_response_to="57915" status_type="SUCCESS"/>
 '''
+
+STATUS_MESSAGE_UNAUTHORIZED = """\
+<?xml version="1.0"?>
+<taxii_11:Status_Message
+    xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1"
+    xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1"
+    xmlns:tdq="http://taxii.mitre.org/query/taxii_default_query-1"
+    message_id="1209263632454336330"
+    in_response_to="0"
+    status_type="UNAUTHORIZED"/>
+"""


### PR DESCRIPTION
When using a cabby client for a longer period, for example when polling large collections, the JWT can expire. When a token is expired OpenTaxii returns a TAXII `UNAUTHORIZED` Status Message. `cabby` raises an`UnsuccessfulStatusError` in that case. After this change the client captures that exception once, calls `refresh_jwt_token` and tries the same request again.

This approach was chosen instead of checking expiration time because it is simpler to implement and less assumptions are needed where and how expiration time are encoded in the JWT.

Note that generic HTTP errors such as 401 or 403 are not dealt with, only TAXII messages.

Minor related changes:
 * Fix a bug when raising `UnsuccessfulStatusError` because `self.raw` is not defined.
 * Update the `session.auth` in `refresh_jwt_token` function as that is what callers would expect (otherwise calling `dispatcher.set_jwt_token` is needed after refreshing).