### PR TITLE
Ensure jwt_token is used if present

### DIFF
--- a/cabby/abstract.py
+++ b/cabby/abstract.py
@@ -158,7 +158,9 @@ class AbstractClient(object):
             key_file=self.key_file,
             key_password=self.key_password,
             ca_cert=self.ca_cert,
-            verify_ssl=self.verify_ssl)
+            verify_ssl=self.verify_ssl,
+            jwt_token=self.jwt_token,
+        )
 
     def _execute_request(self, request, uri=None, service_type=None):
         '''

--- a/cabby/dispatcher.py
+++ b/cabby/dispatcher.py
@@ -304,16 +304,17 @@ class JWTAuth(AuthBase):
 
 
 def get_generic_session(
-        proxies=None,
-        headers=None,
-        username=None,
-        password=None,
-        cert_file=None,
-        key_file=None,
-        key_password=None,
-        ca_cert=None,
-        verify_ssl=True):
-
+    proxies=None,
+    headers=None,
+    username=None,
+    password=None,
+    cert_file=None,
+    key_file=None,
+    key_password=None,
+    ca_cert=None,
+    verify_ssl=True,
+    jwt_token=None,
+):
     session = requests.Session()
     if ca_cert:
         session.verify = ca_cert
@@ -328,6 +329,8 @@ def get_generic_session(
         session.auth = HTTPBasicAuth(username, password)
     if cert_file and key_file:
         session.cert = (cert_file, key_file)
+    if jwt_token:
+        session.auth = JWTAuth(jwt_token)
     session._cabby_key_password = key_password
     return session
 


### PR DESCRIPTION
In some use cases the `Client.jwt_token` is set directly. A bug was introduced in #76 that would cause the JWT not to be included in the request in this case.
This change fixes that and adds a test.