### PR TITLE
Fix recursive fulfillment

### DIFF
--- a/cabby/client11.py
+++ b/cabby/client11.py
@@ -503,6 +503,10 @@ class Client11(AbstractClient):
                     part_number=part, uri=uri)
 
                 for block in fulfilment_stream:
+                    if block is None:
+                        # Break fulilment loop when PollResponse.more is false
+                        has_data = False
+                        break
                     has_data = True
                     yield block
 
@@ -545,5 +549,9 @@ class Client11(AbstractClient):
                                        service_type=const.SVC_POLL)
 
         for obj in stream:
-            if isinstance(obj, tm11.ContentBlock):
+            if isinstance(obj, tm11.PollResponse):
+                # Verify if more ContentBlocks are available
+                if not obj.more:
+                    yield
+            elif isinstance(obj, tm11.ContentBlock):
                 yield to_content_block_entity(obj)

--- a/cabby/client11.py
+++ b/cabby/client11.py
@@ -504,7 +504,7 @@ class Client11(AbstractClient):
 
                 for block in fulfilment_stream:
                     if block is None:
-                        # Break fulilment loop when PollResponse.more is false
+                        # Break fulfilment loop when PollResponse.more is false
                         has_data = False
                         break
                     has_data = True

--- a/tests/test_client11.py
+++ b/tests/test_client11.py
@@ -246,6 +246,9 @@ def test_poll_with_fullfilment():
     assert message.collection_name == POLL_COLLECTION
     assert message.result_part_number == 2
 
+    with pytest.raises(StopIteration):
+        next(gen)
+
 
 @responses.activate
 def test_poll_with_content_bindings():


### PR DESCRIPTION
Fix for infinite loop in fulfilment logic not checking the more property on PollResponse. This was causing a possible `lxml.etree.XMLSyntaxError: no element found` if the taxii server responded with an empty binary body when the loop went past the available ContentBlocks

Fixes: #79 